### PR TITLE
Login history and hardware model tracking

### DIFF
--- a/app/controllers/LoginHistoryController.scala
+++ b/app/controllers/LoginHistoryController.scala
@@ -2,7 +2,6 @@ package controllers
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
-import com.sksamuel.elastic4s.http.ElasticDsl.{fieldSort, update}
 import helpers.{ESClientManager, ZonedDateTimeEncoder}
 import javax.inject.{Inject, Singleton}
 import models.RecentLogin

--- a/app/controllers/LoginHistoryController.scala
+++ b/app/controllers/LoginHistoryController.scala
@@ -1,0 +1,91 @@
+package controllers
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import com.sksamuel.elastic4s.http.ElasticDsl.{fieldSort, update}
+import helpers.{ESClientManager, ZonedDateTimeEncoder}
+import javax.inject.{Inject, Singleton}
+import models.RecentLogin
+import play.api.{Configuration, Logger}
+import play.api.http.{DefaultHttpErrorHandler, HttpErrorHandler, ParserConfiguration}
+import play.api.libs.Files.TemporaryFileCreator
+import play.api.libs.circe.Circe
+import play.api.mvc.{AbstractController, ControllerComponents, PlayBodyParsers}
+import responses.{GenericErrorResponse, ObjectListResponse}
+import io.circe.syntax._
+import io.circe.generic.auto._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@Singleton
+class LoginHistoryController @Inject()(playConfig:Configuration,cc:ControllerComponents,
+                                       defaultTempFileCreator:TemporaryFileCreator, esClientMgr:ESClientManager)(implicit system:ActorSystem)
+  extends AbstractController(cc) with PlayBodyParsers with ZonedDateTimeEncoder with Circe {
+  import com.sksamuel.elastic4s.http.ElasticDsl._
+  import com.sksamuel.elastic4s.circe._
+
+  private val logger = Logger(getClass)
+  implicit def materializer:Materializer = ActorMaterializer()
+
+
+  protected val indexName = playConfig.get[String]("elasticsearch.indexName")
+  protected val loginsIndex = playConfig.get[String]("elasticsearch.loginsIndexName")
+  override def config:ParserConfiguration = {
+    ParserConfiguration(2048*1024,10*1024*1024)
+  }
+
+  override def errorHandler:HttpErrorHandler = DefaultHttpErrorHandler
+
+  override def temporaryFileCreator:TemporaryFileCreator = defaultTempFileCreator
+
+  def updateLogins = Action.async(parse.xml) { request=>
+    val client = esClientMgr.getClient()
+    val maybeLoginsList = (request.body \ "recentLogins").map(RecentLogin.fromXml(_))
+
+    val errors = maybeLoginsList.collect({
+      case Left(err)=>err
+    })
+
+    if(errors.nonEmpty){
+      Future(BadRequest(GenericErrorResponse("bad_data", errors.mkString(";")).asJson))
+    } else {
+      val loginsList = maybeLoginsList.collect({
+        case Right(log)=>log
+      })
+      val resulFutures = Future.traverse(loginsList) { loginEntry=>
+        client.execute {
+          update(loginEntry.idForElastic).in(s"$loginsIndex/login").docAsUpsert(loginEntry)
+        }
+      }
+      resulFutures.map(results=>{
+        val outErrors = results.collect({case Left(err)=>err})
+        if(outErrors.nonEmpty){
+          InternalServerError(GenericErrorResponse("index_error", outErrors.mkString(";")).asJson)
+        } else {
+          Ok(GenericErrorResponse("ok", s"${results.length} records stored").asJson)
+        }
+      })
+    }
+  }
+
+  def loginsFor(hostName:String, limit:Option[Int]) = Action.async {
+    val client = esClientMgr.getClient()
+
+    val actualLimit = limit match {
+      case Some(lim)=>lim
+      case None=>10
+    }
+
+    val resultFuture = client.execute {
+      search(s"$loginsIndex/login") query {
+        termQuery("hostname", hostName)
+      } sortByFieldDesc "loginTime" limit actualLimit
+    }
+
+    resultFuture.map({
+      case Left(err)=>InternalServerError(GenericErrorResponse("search_error", err.toString).asJson)
+      case Right(results)=>Ok(ObjectListResponse("ok","login_history", results.result.to[RecentLogin], results.result.totalHits.toInt).asJson)
+    })
+  }
+}

--- a/app/helpers/ESClientManager.scala
+++ b/app/helpers/ESClientManager.scala
@@ -1,7 +1,7 @@
 package helpers
 
 import com.sksamuel.elastic4s.ElasticsearchClientUri
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import com.sksamuel.elastic4s.http.{HttpClient, RequestFailure}
 
@@ -9,6 +9,7 @@ trait ESClientManager {
   def getClient():HttpClient
 }
 
+@Singleton
 class ESClientManagerImpl @Inject()(config:Configuration) extends ESClientManager {
   val esHost:String = config.get[String]("elasticsearch.hostname")
   val esPort:Int = config.get[Int]("elasticsearch.port")

--- a/app/models/HostInfo.scala
+++ b/app/models/HostInfo.scala
@@ -27,4 +27,5 @@ object HostInfo extends ((String,String,List[String],Option[FCInfo], ZonedDateTi
       Left(ex.toString)
   }
 }
+
 case class HostInfo(hostName:String, computerName:String, ipAddresses: List[String], fibreChannel:Option[FCInfo], lastUpdate:ZonedDateTime)

--- a/app/models/HostInfo.scala
+++ b/app/models/HostInfo.scala
@@ -6,7 +6,7 @@ import io.circe.generic.auto
 
 import scala.xml.NodeSeq
 
-object HostInfo extends ((String,String,List[String],Option[FCInfo], ZonedDateTime)=>HostInfo) {
+object HostInfo extends ((String,String,String,String,List[String],Option[FCInfo], ZonedDateTime)=>HostInfo) {
   def fromXml(xml:NodeSeq, timestamp:ZonedDateTime):Either[String, HostInfo] = try {
     val fcInfos = if ((xml \ "fibrechannel").length==0){
       None
@@ -21,11 +21,12 @@ object HostInfo extends ((String,String,List[String],Option[FCInfo], ZonedDateTi
           }
       }
     }
-    Right(new HostInfo(xml \@ "hostname",xml \@ "computerName", (xml \ "ipAddresses").map(_.text).toList, fcInfos, timestamp))
+    Right(new HostInfo(xml \@ "hostname",xml \@ "computerName", xml \@ "model", xml \@ "hw_uuid",
+      (xml \ "ipAddresses").map(_.text).toList, fcInfos, timestamp))
   } catch {
     case ex:Throwable=>
       Left(ex.toString)
   }
 }
 
-case class HostInfo(hostName:String, computerName:String, ipAddresses: List[String], fibreChannel:Option[FCInfo], lastUpdate:ZonedDateTime)
+case class HostInfo(hostName:String, computerName:String, model:String, hwUUID:String, ipAddresses: List[String], fibreChannel:Option[FCInfo], lastUpdate:ZonedDateTime)

--- a/app/models/RecentLogin.scala
+++ b/app/models/RecentLogin.scala
@@ -1,0 +1,49 @@
+package models
+
+import java.time.{Duration, LocalDateTime}
+
+import scala.xml.NodeSeq
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.{ChronoField, ChronoUnit, TemporalAccessor, TemporalUnit}
+
+object RecentLogin extends ((String, String, String, LocalDateTime, Duration)=>RecentLogin) {
+  private val rubbishFormat = new DateTimeFormatterBuilder()
+    .appendPattern("EE MMM d HH:mm:ss")
+    .parseStrict()
+    .parseDefaulting(ChronoField.YEAR, LocalDateTime.now().get(ChronoField.YEAR))
+    .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+    .toFormatter()
+
+  def durationFromXmlObj(xml: NodeSeq):Duration = {
+    val days = (xml \@ "days").toLong
+    val hours = (xml \@ "hours").toLong
+    val minutes = (xml \@ "minutes").toLong
+
+    val totalSeconds = days*3600L*24L + hours *3600L + minutes*60L
+    Duration.of(totalSeconds, ChronoUnit.SECONDS)
+  }
+
+  def fromXml(xml:NodeSeq):Either[String,RecentLogin] = try {
+    val lastLoginTime = (xml \@ "login").replaceAll("  +", " ") + ":00"
+    val parsed = rubbishFormat.parse(lastLoginTime)
+
+    Right(new RecentLogin(
+      xml \@ "hostname", xml \@ "username", xml \@ "location", LocalDateTime.from(parsed), durationFromXmlObj(xml \ "duration")
+    ))
+  } catch {
+    case ex:Throwable=>
+      Left(ex.toString)
+  }
+}
+
+case class RecentLogin(hostname:String, username:String,location:String,loginTime:LocalDateTime,duration:Duration) {
+  /**
+    * generate a unique ID for this login for the index
+    * @return
+    */
+  def idForElastic:String = {
+    val encoder = java.util.Base64.getEncoder
+    val rawString=s"$username@$hostname@${loginTime.format(DateTimeFormatter.ISO_DATE_TIME)}"
+    encoder.encodeToString(rawString.toCharArray.map(_.toByte))
+  }
+}

--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -78,7 +78,7 @@ sub breakdownLongDate {
 }
 
 sub getLoginHistory {
-    my $rawHistory = `last | grep console | grep -v localhome | head`;
+    my $rawHistory = `last | grep console |  head`;
     my @result;
 
     foreach(split(/\n/, $rawHistory)){
@@ -165,10 +165,10 @@ if($format eq "text"){
     "hostname"=>$hostname,
     "computerName"=>$computerName,
     "ipAddresses"=>\@ipInfo,
-    "fibrechannel"=>$fibreInfo,
-      "recentLogins"=>$recentLogins
+    "fibrechannel"=>$fibreInfo
   };
     my $content = XMLout($data,RootName=>"data", KeyAttr=>[ ]);
+    my $loginsContent = XMLout($recentLogins,RootName=>"logins");
 
     if($outputUri){
         my $ua=LWP::UserAgent->new;
@@ -183,5 +183,6 @@ if($format eq "text"){
         }
     } else {
         print $content . "\n";
+        print $loginsContent . "\n";
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -274,4 +274,5 @@ elasticsearch {
   port = 9200
   ssl = false
   indexName = "fibre-census"
+  loginsIndexName = "workstation-logins"
 }

--- a/conf/routes
+++ b/conf/routes
@@ -12,3 +12,6 @@ GET     /assets/*file               controllers.Assets.versioned(path="/public",
 GET     /healthcheck                controllers.HomeController.healthcheck
 GET     /api/search/basic      @controllers.HostInfoController.simpleStringSearch(q:Option[String],start:Option[Int],length:Option[Int])
 POST    /api/hostinfo                   @controllers.HostInfoController.addRecord
+
+POST    /api/logins             @controllers.LoginHistoryController.updateLogins
+GET     /api/logins/:hostname   @controllers.LoginHistoryController.loginsFor(hostname,limit:Option[Int])

--- a/deployment/elasticsearch.yaml
+++ b/deployment/elasticsearch.yaml
@@ -32,7 +32,7 @@ spec:
         - name: bootstrap.memory_lock
           value: "true"
         - name: cluster.name
-          value: VidispineES
+          value: FibreCensusES
         - name: discovery.zen.ping.unicast.hosts
           value: fc-es-cluster
         image: andyg42/elasticsearch-noxpack-analysisicu:5.6.11

--- a/frontend/app/FrontPage.jsx
+++ b/frontend/app/FrontPage.jsx
@@ -6,6 +6,8 @@ import axios from 'axios';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import TimestampFormatter from "./common/TimestampFormatter.jsx";
 import ErrorViewComponent from "./common/ErrorViewComponent.jsx";
+import UserHistoryComponent from './UserHistoryComponent.jsx';
+import ReactTooltip from 'react-tooltip';
 
 class FrontPage extends React.Component {
     constructor(props){
@@ -30,9 +32,20 @@ class FrontPage extends React.Component {
                 headerProps: { className: 'dashboardheader'}
             },
             {
+                header: "Model",
+                key: "model",
+                headerProps: { className: 'dashboardheader'}
+            },
+            {
                 header: "Computer Name",
                 key: "computerName",
                 headerProps: { className: 'dashboardheader'}
+            },
+            {
+                header: "Last User",
+                key: "hostName",
+                headerProps: { className: 'dashboardheader'},
+                render: (hostname)=><UserHistoryComponent hostname={hostname} limit={1}/>
             },
             {
                 header: "IP Addressess",
@@ -82,7 +95,7 @@ class FrontPage extends React.Component {
             results: [],
             loading: false,
             lastError: null,
-            showRelativeTime: false
+            showRelativeTime: true
         };
 
         this.updateSearchTerms = this.updateSearchTerms.bind(this);
@@ -111,10 +124,13 @@ class FrontPage extends React.Component {
         return Object.assign({
             "hostName": rawData.hostName,
             "computerName": rawData.computerName,
+            "model": rawData.model,
+            "hwUUID": rawData.hwUUID,
             "ipAddresses": rawData.ipAddresses,
             "lastUpdate": rawData.lastUpdate
         }, fcData)
     }
+
     refresh(){
         const searchTerm = encodeURIComponent(this.state.searchTerm ? this.state.searchTerm : "*");
 
@@ -149,6 +165,7 @@ class FrontPage extends React.Component {
                 />
             }
             </div>
+            <ReactTooltip className="generic-tooltip"/>
         </div>
 
     }

--- a/frontend/app/UserHistoryComponent.jsx
+++ b/frontend/app/UserHistoryComponent.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import ReactTooltip from 'react-tooltip';
+
+class UserHistoryComponent extends React.Component {
+    static propTypes = {
+        hostname: PropTypes.string.isRequired,
+        limit: PropTypes.number
+    };
+
+    static durationExtractor = new RegExp('\w{2}(\d+)H(\d+)M');
+
+    constructor(props){
+        super(props);
+        this.state = {
+            loading: false,
+            lastError: null,
+            records: []
+        };
+    }
+
+    componentWillMount(){
+        const limit = this.props.limit ? this.props.limit : 1;
+        const hostParts = this.props.hostname.split(".");
+
+        this.setState({loading: true, lastError: null},
+            ()=>axios.get("/api/logins/" + hostParts[0] + "?limit=" + limit)
+                .then(response=>{
+                    this.setState({loading: false, lastError: null, records: response.data.entries})
+                })
+                .catch(err=>{
+                    this.setState({loading: false, lastError: err})
+                })
+        )
+    }
+
+    details(entry){
+        return "On " + entry.location + " at " + entry.loginTime + " for " + this.niceifyDuration(entry.duration)
+    }
+
+    niceifyDuration(durationString){
+        try {
+            const values = durationString.match(UserHistoryComponent.durationExtractor);
+            if (values) return values[1] + " hours, " + values[2] + " minutes";
+        }catch (err){
+            console.error(err);
+            return durationString;
+        }
+    }
+
+    render() {
+        return <ul className="addressList">
+            {
+                this.state.records.map(entry=><li key={entry.loginTime} data-tip={this.details(entry)}>{entry.username}</li>)
+            }
+        </ul>
+    }
+}
+
+export default UserHistoryComponent;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -123,3 +123,7 @@ ul.addressList {
     font-size: 0.7em;
     font-style: italic;
 }
+
+.generic-tooltip {
+    z-index: 99;
+}

--- a/test/HostInfoSpec.scala
+++ b/test/HostInfoSpec.scala
@@ -11,7 +11,7 @@ class HostInfoSpec extends Specification {
   "HostInfo.fromXML" should {
     "convert an xml doc with no fibrechannel info into a HostInfo model" in {
       val sampleXml = """<?xml version="1.0" encoding="UTF-8"?>
-                        |<data computerName="33212_TV01_MMED_TEC_LOCADM_" hostname="33212.gnm.int">
+                        |<data model="something" hw_uuid="fakeid" computerName="33212_TV01_MMED_TEC_LOCADM_" hostname="33212.gnm.int">
                         |  <fibrechannel></fibrechannel>
                         |    <ipAddresses>192.168.1.108</ipAddresses>
                         |    <ipAddresses>192.168.1.12</ipAddresses>
@@ -21,24 +21,24 @@ class HostInfoSpec extends Specification {
       val doc = parser.document().docElem
       val t = ZonedDateTime.now()
       val result = HostInfo.fromXml(doc, t)
-      result must beRight(HostInfo("33212.gnm.int","33212_TV01_MMED_TEC_LOCADM_",List("192.168.1.108","192.168.1.12","192.168.1.19"),None,t))
+      result must beRight(HostInfo("33212.gnm.int","33212_TV01_MMED_TEC_LOCADM_","something","fakeid",List("192.168.1.108","192.168.1.12","192.168.1.19"),None,t))
     }
 
     "convert an xml doc with fibrechannel info into a HostInfo model" in {
       val sampleXml = """<?xml version="1.0"?>
-                        |<data computerName="32811_TV06_B300_K3_MMEDIA_1" hostname="32811.gnm.int">
+                        |<data model="something" hw_uuid="fakeid" computerName="32811_TV06_B300_K3_MMEDIA_1" hostname="32811.gnm.int">
                         |  <fibrechannel Product="ATTO ThunderLink FC 2082">
                         |    <Domain_0 WWN="10:00:00:10:86:04:09:AA" lunCount="0"/>
                         |    <Domain_1 Speed="Automatic (8 Gigabit)" Status="Link Established" WWN="24:70:00:C0:FF:1B:00:2C" lunCount="120"/>
                         |  </fibrechannel>
                         |  <ipAddresses>10.232.244.28</ipAddresses>
                         |  <ipAddresses>192.168.51.23</ipAddresses>
-                        |</data>"""
+                        |</data>""".stripMargin
       val parser = ConstructingParser.fromSource(Source.fromString(sampleXml), preserveWS = false)
       val doc = parser.document().docElem
       val t = ZonedDateTime.now()
       val result = HostInfo.fromXml(doc, t)
-      result must beRight(HostInfo("32811.gnm.int","32811_TV06_B300_K3_MMEDIA_1",
+      result must beRight(HostInfo("32811.gnm.int","32811_TV06_B300_K3_MMEDIA_1","something","fakeid",
         List("10.232.244.28","192.168.51.23"),
         Some(FCInfo(
           Seq(

--- a/test/HostInfoSpec.scala
+++ b/test/HostInfoSpec.scala
@@ -1,7 +1,7 @@
-import java.time.ZonedDateTime
+import java.time.{Duration, LocalDateTime, ZonedDateTime}
 
 import org.specs2.mutable._
-import models.{FCDomain, FCInfo, HostInfo}
+import models.{FCDomain, FCInfo, HostInfo, RecentLogin}
 
 import scala.io.Source
 import scala.xml.parsing.ConstructingParser
@@ -47,7 +47,6 @@ class HostInfoSpec extends Specification {
           ),"ATTO ThunderLink FC 2082"
         )),
         t))
-
     }
   }
 }

--- a/test/RecentLoginSpec.scala
+++ b/test/RecentLoginSpec.scala
@@ -1,0 +1,28 @@
+import java.time.temporal.TemporalAmount
+import java.time.{Duration, LocalDateTime, ZonedDateTime}
+
+import models.RecentLogin
+import org.specs2.mutable._
+
+import scala.io.Source
+import scala.xml.parsing.ConstructingParser
+
+class RecentLoginSpec extends Specification {
+  "RecentLogin.fromXml" should {
+    "process a parsed xml fragment" in {
+      val sampleXml = "<recentLogins hostname=\"mycomputer\" location=\"console\" login=\"Sun Oct  7 11:41\" username=\"localhome\">\n    <duration days=\"0\" hours=\"23\" minutes=\"57\" />\n  </recentLogins>"
+      val parser = ConstructingParser.fromSource(Source.fromString(sampleXml), preserveWS = false)
+      val doc = parser.document().docElem
+      val t = ZonedDateTime.now()
+      val result = RecentLogin.fromXml(doc)
+
+      result must beRight(RecentLogin(
+        "mycomputer",
+        "localhome",
+        "console",
+        LocalDateTime.of(2018,10,7,11,41),
+        Duration.ofSeconds(86220)
+      ))
+    }
+  }
+}


### PR DESCRIPTION
Server side can now track login history via a separate controller populating a separate index.  Updates to frontend to present last logged in user for the given machine.
Client-side script generates this data by parsing the output of `last`, limiting to the most recent 8 lines or so.

Also adding fields for hardware model and hardware UUID, storing in the main HostInfo model and presenting in UI