### PR TITLE
Get Ping, Xsand, and Mount Information and Render it to Text or XML

### DIFF
--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -260,16 +260,14 @@ sub pingMetaDataControllers {
         $packetLoss = '0';
       } else {
         $pingStatus = 'false';
-        my $pingCount = 1;
         my $pingResults = 0;
-        for($pingCount=0;$pingCount<=10;++$pingCount) {
+        for($pingCount=1;$pingCount<=10;++$pingCount) {
           my $pingResultTwo = doPing($_);
           if (defined $pingResultTwo) {
             $pingStatus = 'true';
           } else {
             $pingResults++;
           }
-          $pingCount++;
         }
         $percentagePacketLoss = $pingResults * 10;
       }

--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -214,7 +214,7 @@ sub checkMounts {
   my $mountInt=1;
   my $data = {};
   foreach(split(/\n/, $mountsContent)){
-	my @fields = split / /, $_;
+    my @fields = split / /, $_;
 	my @fieldsParts = split /\//, $fields[2];
     $data->{"$mountInt"}->{"mountPath"}="$fields[2]";
     $data->{"$mountInt"}->{"name"}="$fieldsParts[-1]";

--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -201,7 +201,7 @@ sub printkv {
 sub checkXsand {
   my $xsandContent = `pgrep xsand`;
   if ($xsandContent eq '') {
-  	return 'Not running';
+    return 'Not running';
   } else {
     return 'Running';
   }

--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -13,7 +13,6 @@ use File::Slurp;
 my $format="text";
 my $useXml;
 my $outputUri;
-
 GetOptions("xml"=>\$useXml, "out=s"=>\$outputUri);
 
 $format="xml" if($useXml);

--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -250,20 +250,11 @@ sub pingMetaDataControllers {
 	if (defined $pingResult) {
       $pingStatus = 'true';
       $packetLoss = '0';
-      print "Ping sucessful\n";
-      print "IP: $_\n";
-      print "Ping Status: $pingStatus\n";
-      print "Packet Loss: $packetLoss\n";
     } else {
       $pingStatus = 'false';
-      print "Ping failed\n";
-      print "IP: $_\n";
-      print "Ping Status: $pingStatus\n";
-      print "Attempting ten more pings...\n";
       my $pingCount = 1;
       my $pingResults = 0;
       while ($pingCount < 11) {
-        print "pinging\n";
         my $pingContentTwo = `ping -c 1 $_`;
         my @pingContentArrayTwo = split /\n/, $pingContentTwo;
         my $pingResultTwo;
@@ -276,17 +267,12 @@ sub pingMetaDataControllers {
         use warnings 'substr';
         if (defined $pingResultTwo) {
           $pingStatus = 'true';
-          print "Ping sucessful\n";
-          print "IP: $_\n";
         } else {
           $pingResults++;
-          print "Ping failed\n";
-          print "IP: $_\n";
         }
         $pingCount++;
       }
       $percentagePacketLoss = $pingResults * 10;
-      print "Packet Loss: $percentagePacketLoss%\n";
     }
     my $percentagePacketLossForXML = 0;
     if ($percentagePacketLoss != 0) {

--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -15,6 +15,7 @@ my $useXml;
 my $outputUri;
 GetOptions("xml"=>\$useXml, "out=s"=>\$outputUri);
 
+
 $format="xml" if($useXml);
 
 my $hostname = `hostname`;


### PR DESCRIPTION
Executes methods that ping the meta data controllers, check if xsand is running, and check which volumes are mounted. The results are then rendered to text or XML.

Here are some example segments from XML renders: -

```
<XsandStatus status="Running" />

  <mdcConnectivity>
    <mdc ip="192.168.51.2" number="1" packetloss="0" ping="true" />
    <mdc ip="192.168.51.3" number="2" packetloss="0" ping="true" />
  </mdcConnectivity>

  <sanVolumesVisible>
    <mount mountPath="/Volumes/StudioPipe2" name="StudioPipe2" number="3" />
    <mount mountPath="/Volumes/Multimedia2" name="Multimedia2" number="2" />
    <mount mountPath="/Volumes/Proxies2" name="Proxies2" number="1" />
  </sanVolumesVisible>
```

Tested on a workstation running macOS 10.11.6.

@fredex42 