### PR TITLE
Ignore DLC Errors if the Model is a Mac Studio

### DIFF
--- a/frontend/app/validation.jsx
+++ b/frontend/app/validation.jsx
@@ -59,8 +59,9 @@ function validateRecord(record){
 
     if(!record.sanMounts) return "info";
 
-
-    if(mustHaveVolumes.filter(entry=>!record.denyDlcVolumes.includes(entry)).length>0) return "info";
+    if(record.model!=="Mac Studio") {
+        if (mustHaveVolumes.filter(entry => !record.denyDlcVolumes.includes(entry)).length > 0) return "info";
+    }
     return "normal";
 }
 


### PR DESCRIPTION
## What does this change?

Ignores any DLC data errors if the model is a Mac Studio. The Mac Studios have seen set up with different setting and the validation code was showing false errors.

## How can we measure success?

Correct settings for Mac Studios no longer show as errors.

Tested on the live system.