### PR TITLE
Changing Box Widths and Making Client Script get Internet Protocol Addresses More Reliably

### DIFF
--- a/client_script/profile_reader.pl
+++ b/client_script/profile_reader.pl
@@ -255,7 +255,12 @@ sub pingMetaDataControllers {
   foreach(split(/\n/, $xsanNameServersConfigFile)){
       my $pingStatus;
       my $packetLoss;
-      my $pingResult = doPing($_);
+      my $iPAddress = $_;
+      if($iPAddress =~ /(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/)
+      {
+        $iPAddress = $1;
+      }
+      my $pingResult = doPing($iPAddress);
       if (defined $pingResult) {
         $pingStatus = 'true';
         $packetLoss = '0';
@@ -263,7 +268,7 @@ sub pingMetaDataControllers {
         $pingStatus = 'false';
         my $pingResults = 0;
         for($pingCount=1;$pingCount<=10;++$pingCount) {
-          my $pingResultTwo = doPing($_);
+          my $pingResultTwo = doPing($iPAddress);
           if (defined $pingResultTwo) {
             $pingStatus = 'true';
           } else {
@@ -276,7 +281,7 @@ sub pingMetaDataControllers {
     if ($percentagePacketLoss != 0) {
       $percentagePacketLossForXML = $percentagePacketLoss;
     }
-    $data->{"$pingInt"}->{"ip"}="$_";
+    $data->{"$pingInt"}->{"ip"}="$iPAddress";
     $data->{"$pingInt"}->{"ping"}="$pingStatus";
     $data->{"$pingInt"}->{"packetloss"}="$percentagePacketLossForXML";
     $pingInt = $pingInt + 1;

--- a/frontend/app/NewFrontPage.jsx
+++ b/frontend/app/NewFrontPage.jsx
@@ -195,8 +195,8 @@ class NewFrontPage extends React.Component {
                         <DisplayTextList title="IP Addresses"
                                          bulletIcon="network-wired"
                                          listData={entry.ipAddresses}
-                                         validationComponent={<ValidateIpAddresses listData={entry.ipAddresses}
-                                         extraClasses="ip"/>}
+                                         validationComponent={<ValidateIpAddresses listData={entry.ipAddresses}/>}
+                                         extraClasses="ip"
                         />
                         <DisplayRecentUsers title="Recent Users" entry={entry} extraClasses="doublewidth"/>
                         <DisplayTextList title="Fibre WWNs" listData={entry.fcWWN} extraClasses="fibre" validationComponent={<ValidateFCWWN listData={entry.fcWWN}/>}/>
@@ -205,8 +205,8 @@ class NewFrontPage extends React.Component {
                         <DisplayTextList title="LUN count" listData={entry.fcLunCount} validationComponent={<ValidateLunCount listData={entry.fcLunCount}/>} extraClasses="lun"/>
                         <DisplayTextList title="UseDLC"
                                          listData={entry.denyDlcVolumes}
-                                         validationComponent={<ValidateDLC listData={entry.denyDlcVolumes}
-                                         extraClasses="dlc"/>}
+                                         validationComponent={<ValidateDLC listData={entry.denyDlcVolumes}/>}
+                                         extraClasses="dlc"
                         />
                         <DisplaySimpleText title="Fibre adaptor model" entry={entry.fcAdaptor} extraClasses="wider"/>
                         <DisplayMdcPing title="MDC Controller Connectivity"

--- a/frontend/app/NewFrontPage.jsx
+++ b/frontend/app/NewFrontPage.jsx
@@ -191,7 +191,7 @@ class NewFrontPage extends React.Component {
                                              extraClasses="oversized float-right"
                         />
                         <DisplaySimpleText title="Model" entry={entry.model} validationComponent={<ValidateModel stringData={entry.model}/>}/>
-                        <DisplaySimpleText title="Computer Name" entry={entry.computerName} extraClasses="wider"/>
+                        <DisplaySimpleText title="Computer Name" entry={entry.computerName} extraClasses="even-wider"/>
                         <DisplayTextList title="IP Addresses"
                                          bulletIcon="network-wired"
                                          listData={entry.ipAddresses}

--- a/frontend/app/NewFrontPage.jsx
+++ b/frontend/app/NewFrontPage.jsx
@@ -190,21 +190,23 @@ class NewFrontPage extends React.Component {
                                              validationComponent={<ValidateFibreDrivers listData={entry.driverInfo}/>}
                                              extraClasses="oversized float-right"
                         />
-                        <DisplaySimpleText title="Model" entry={entry.model} validationComponent={<ValidateModel stringData={entry.model}/>}/>
+                        <DisplaySimpleText title="Model" entry={entry.model} validationComponent={<ValidateModel stringData={entry.model}/>} extraClasses="model"/>
                         <DisplaySimpleText title="Computer Name" entry={entry.computerName} extraClasses="even-wider"/>
                         <DisplayTextList title="IP Addresses"
                                          bulletIcon="network-wired"
                                          listData={entry.ipAddresses}
-                                         validationComponent={<ValidateIpAddresses listData={entry.ipAddresses}/>}
+                                         validationComponent={<ValidateIpAddresses listData={entry.ipAddresses}
+                                         extraClasses="ip"/>}
                         />
                         <DisplayRecentUsers title="Recent Users" entry={entry} extraClasses="doublewidth"/>
-                        <DisplayTextList title="Fibre WWNs" listData={entry.fcWWN} extraClasses="wider" validationComponent={<ValidateFCWWN listData={entry.fcWWN}/>}/>
+                        <DisplayTextList title="Fibre WWNs" listData={entry.fcWWN} extraClasses="fibre" validationComponent={<ValidateFCWWN listData={entry.fcWWN}/>}/>
                         <DisplayTextList title="Fibre status" listData={entry.fcStatus}/>
                         <DisplayTextList title="Fibre speed" listData={entry.fcSpeed}/>
-                        <DisplayTextList title="LUN count" listData={entry.fcLunCount} validationComponent={<ValidateLunCount listData={entry.fcLunCount}/>}/>
+                        <DisplayTextList title="LUN count" listData={entry.fcLunCount} validationComponent={<ValidateLunCount listData={entry.fcLunCount}/>} extraClasses="lun"/>
                         <DisplayTextList title="UseDLC"
                                          listData={entry.denyDlcVolumes}
-                                         validationComponent={<ValidateDLC listData={entry.denyDlcVolumes}/>}
+                                         validationComponent={<ValidateDLC listData={entry.denyDlcVolumes}
+                                         extraClasses="dlc"/>}
                         />
                         <DisplaySimpleText title="Fibre adaptor model" entry={entry.fcAdaptor} extraClasses="wider"/>
                         <DisplayMdcPing title="MDC Controller Connectivity"

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -264,3 +264,23 @@ ul.content-list {
 .even-wider {
     width: 320px !important;
 }
+
+.fibre {
+    width: 226px !important;
+}
+
+.model {
+    width: 114px !important;
+}
+
+.ip {
+    width: 170px !important;
+}
+
+.lun {
+    width: 130px !important;
+}
+
+.dlc {
+    width: 110px !important;
+}

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -260,3 +260,7 @@ ul.content-list {
     margin-left: auto;
     margin-right: 0.5em;
 }
+
+.even-wider {
+    width: 320px !important;
+}


### PR DESCRIPTION
## What does this change?

Makes the page neater by changing various box widths. Changes the client script, adding a regex to get IP addresses from a string.

## How can we measure success?

The page looks neater. IP addresses in longer strings are read correctly.

Tested on the dev. system.