### PR TITLE
Add Wildcard Asterisks Either Side of Search Input

### DIFF
--- a/app/controllers/HostInfoController.scala
+++ b/app/controllers/HostInfoController.scala
@@ -74,8 +74,9 @@ class HostInfoController @Inject()(playConfig:Configuration,cc:ControllerCompone
 
     q match {
       case Some(searchTerms) =>
+        val searchString = s"*$searchTerms*"
         val responseFuture = cli.execute {
-          search(indexName) query searchTerms from actualStart size actualLength
+          search(indexName) query searchString from actualStart size actualLength
         }
 
         responseFuture.map({


### PR DESCRIPTION
## What does this change?

Makes search function look for sub-strings by default.

## How can we measure success?

The search input returns results for sub-strings without the user having to add asterisks.

## Images

![Screenshot 2024-06-20 at 10 46 38](https://github.com/guardian/fibre-census/assets/10620802/a03b7b35-08da-4b52-9c61-47c9409ee383)

This was tested on a machine running macOS 12.6.8 and on the dev. system.