### PR TITLE
Fix For Mac Studios Being Flagged as Not Expected to Be Connected to the SAN

### DIFF
--- a/frontend/app/validation/ValidateModel.jsx
+++ b/frontend/app/validation/ValidateModel.jsx
@@ -2,7 +2,7 @@ import ValidationComponent from "./ValidationComponent.jsx";
 
 class ValidateModel extends ValidationComponent {
     performValidation() {
-        if(this.props.stringData==="Mac Pro"){
+        if((this.props.stringData==="Mac Pro") || (this.props.stringData==="Mac Studio")){
             this.setState({"tooltip": ""});
             return "normal";
         } else {


### PR DESCRIPTION
## What does this change?

Stops Mac Studios being flagged as not expected to be connected to the SAN.

## How can we measure success?

Mac Studios should no longer be flagged incorrectly.

## Images

![Screenshot 2024-06-20 at 11 33 50](https://github.com/guardian/fibre-census/assets/10620802/ca328339-cb76-4cc7-a425-208c9584cc65)

Tested on the live system.