### PR TITLE
Time Out and Refresh Keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/app/auth/BearerTokenAuth.scala
+++ b/app/auth/BearerTokenAuth.scala
@@ -74,7 +74,8 @@ class BearerTokenAuth @Inject() (config:Configuration) {
   //see https://stackoverflow.com/questions/475074/regex-to-parse-or-validate-base64-data
   //it is not the best option but is the simplest that will work here
   private val authXtractor = "^Bearer\\s+([a-zA-Z0-9+/._-]*={0,3})$".r
-  private val maybeVerifiers = loadInKey() match {
+  var loadTime: Long = System.currentTimeMillis / 1000
+  private var maybeVerifiers = loadInKey() match {
     case Failure(err)=>
       if(!sys.env.contains("CI")) logger.warn(s"No token validation cert in config so bearer token auth will not work. Error was ${err.getMessage}")
       None
@@ -127,6 +128,7 @@ class BearerTokenAuth @Inject() (config:Configuration) {
     * @return Either an initialised JWKSet or a Failure indicating why it would not load.
     */
   def loadInKey():Try[JWKSet] = Try {
+    loadTime = System.currentTimeMillis / 1000
     val isRemoteMatcher = "^https*:".r.unanchored
 
     signingCertPath match {
@@ -227,6 +229,16 @@ class BearerTokenAuth @Inject() (config:Configuration) {
     logger.debug(s"validating token $token")
     parseTokenContent(token.content) match {
       case Success(signedJWT) =>
+        if ((System.currentTimeMillis / 1000) - loadTime > config.get[Int]("auth.keyTimeOut")) {
+          logger.debug(s"Keys too old. Attempting key refresh.")
+          maybeVerifiers = loadInKey() match {
+            case Failure(err)=>
+              if(!sys.env.contains("CI")) logger.warn(s"Could not load keys. Error was ${err.getMessage}")
+              None
+            case Success(jwk)=>
+              Some(jwk)
+          }
+        }
         getVerifier(Option(signedJWT.getHeader.getKeyID)) match {
           case Some(verifier) =>
             if (signedJWT.verify(verifier)) {


### PR DESCRIPTION
## What does this change?

Times out keys after a certain amount of seconds and attempts to download new keys before they are used.

Requires new setting of auth.keyTimeOut in a number of seconds be present in the application configuration file.

## How can we measure success?

Keys should be invalid less often.

This was tested on the dev. system.