### PR TITLE
Cope if the Deny DLC Volumes List is Empty

### DIFF
--- a/app/controllers/HostInfoController.scala
+++ b/app/controllers/HostInfoController.scala
@@ -117,7 +117,11 @@ class HostInfoController @Inject()(playConfig:Configuration,cc:ControllerCompone
 
     if (entry.model == "Mac Studio") {
       if (!entry.denyDlcVolumes.isEmpty) {
-        if (entry.denyDlcVolumes.get.head != "false") return "warning"
+        if (entry.denyDlcVolumes.get.length > 0) {
+          if (entry.denyDlcVolumes.get.head != "false") return "warning"
+        } else {
+          return "warning"
+        }
       } else {
         return "warning"
       }


### PR DESCRIPTION
## What does this change?

Cope if the Deny DLC Volumes list exists and is empty.

## How can we measure success?

The code on the server sides should no longer break if the Deny DLC Volumes list exists and is empty.

This was tested on a machine running macOS 12.6.8 and on the dev. system.